### PR TITLE
Changed column type from 'bool' to 'boolean'

### DIFF
--- a/db/migrate/20130325055758_add_completed_to_users.rb
+++ b/db/migrate/20130325055758_add_completed_to_users.rb
@@ -1,5 +1,5 @@
 class AddCompletedToUsers < ActiveRecord::Migration
   def change
-    add_column :users, :completed, :bool
+    add_column :users, :completed, :boolean
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -90,7 +90,33 @@ ActiveRecord::Schema.define(:version => 20130325055758) do
     t.datetime "updated_at", :null => false
   end
 
-# Could not dump table "users" because of following StandardError
-#   Unknown type 'bool' for column 'completed'
+  create_table "users", :force => true do |t|
+    t.string   "email",                   :default => "", :null => false
+    t.string   "encrypted_password",      :default => "", :null => false
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer  "sign_in_count",           :default => 0
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string   "current_sign_in_ip"
+    t.string   "last_sign_in_ip"
+    t.datetime "created_at",                              :null => false
+    t.datetime "updated_at",                              :null => false
+    t.boolean  "admin"
+    t.string   "name"
+    t.string   "tlf"
+    t.string   "company"
+    t.boolean  "accepcted_privacy"
+    t.boolean  "accepted_optional_email"
+    t.string   "twitter"
+    t.string   "allergies"
+    t.integer  "ticket_id"
+    t.integer  "order_id"
+    t.boolean  "completed"
+  end
+
+  add_index "users", ["email"], :name => "index_users_on_email", :unique => true
+  add_index "users", ["reset_password_token"], :name => "index_users_on_reset_password_token", :unique => true
 
 end


### PR DESCRIPTION
This was most probably just a spelling error from @ad9b1948, but it made
Rails unable to create a proper schema file, leading to me being unable
to prepare a test database from it.

This is a correction to an already existing migration, which means that
all developers would have to reset their database by running 'rake
db:migrate:reset' and presumably reseeding it with 'rake db:seed'.
