### PR TITLE
Removing empty controller methods

### DIFF
--- a/app/controllers/administration_controller.rb
+++ b/app/controllers/administration_controller.rb
@@ -1,12 +1,3 @@
 class AdministrationController < ApplicationController
 	before_filter :require_admin
-	
-  def registrations
-  end
-
-  def send_mail
-  end
-
-  def statistics
-  end
 end

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -1,10 +1,1 @@
-class InfoController < ApplicationController
-  def index
-  end
-
-	def about
-  end
-
-  def sponsor
-  end
-end
+class InfoController < ApplicationController; end


### PR DESCRIPTION
Rails promotes convention over configuration over anything else and per
documentation, Rails will render a view corresponding to a controller
action by default and the controller method does not even need to be
present.

See http://goo.gl/BJdjD for more information.
