### PR TITLE
Added Annotate and annotations to all models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,10 @@ group :test, :development do
   gem 'factory_girl_rails', :require => false
 end
 
+group :development do
+  gem 'annotate'
+end
+
 group :test do
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,8 @@ GEM
       i18n (~> 0.6)
       multi_json (~> 1.0)
     addressable (2.3.2)
+    annotate (2.5.0)
+      rake
     arel (3.0.2)
     aws-sdk (1.8.1.1)
       json (~> 1.4)
@@ -196,6 +198,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate
   aws-sdk
   bootstrap-sass
   devise

--- a/app/models/manual_payment.rb
+++ b/app/models/manual_payment.rb
@@ -1,4 +1,32 @@
 # encoding: UTF-8
+# == Schema Information
+#
+# Table name: payments
+#
+#  id                    :integer          not null, primary key
+#  price                 :integer
+#  paid_amount           :integer
+#  completed             :boolean
+#  completed_at          :datetime
+#  paypal_params         :text
+#  paypal_tx_id          :string(255)
+#  paypal_tx_type        :string(255)
+#  paypal_currency       :string(255)
+#  paypal_status         :string(255)
+#  paypal_payer_email    :string(255)
+#  manual_company_name   :string(255)
+#  manual_company_email  :string(255)
+#  manual_contact_person :string(255)
+#  manual_street_address :string(255)
+#  manual_post_code      :string(255)
+#  manual_invoice_sent   :boolean
+#  order_id              :integer
+#  type                  :string(255)
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  invoice_id            :string(255)
+#
+
 class ManualPayment < Payment
   attr_accessible :completed, :completed_at, :manual_company_email, :manual_company_name, :manual_contact_person, :manual_invoice_sent, :manual_post_code, :manual_street_address, :paid_amount, :price
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,4 +1,16 @@
 # encoding: UTF-8
+# == Schema Information
+#
+# Table name: orders
+#
+#  id            :integer          not null, primary key
+#  comment       :string(255)
+#  completed     :boolean
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  owner_user_id :integer
+#
+
 class Order < ActiveRecord::Base
   attr_accessible :comment, :completed, :owner_user_id
   has_many :users

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,3 +1,31 @@
+# == Schema Information
+#
+# Table name: payments
+#
+#  id                    :integer          not null, primary key
+#  price                 :integer
+#  paid_amount           :integer
+#  completed             :boolean
+#  completed_at          :datetime
+#  paypal_params         :text
+#  paypal_tx_id          :string(255)
+#  paypal_tx_type        :string(255)
+#  paypal_currency       :string(255)
+#  paypal_status         :string(255)
+#  paypal_payer_email    :string(255)
+#  manual_company_name   :string(255)
+#  manual_company_email  :string(255)
+#  manual_contact_person :string(255)
+#  manual_street_address :string(255)
+#  manual_post_code      :string(255)
+#  manual_invoice_sent   :boolean
+#  order_id              :integer
+#  type                  :string(255)
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  invoice_id            :string(255)
+#
+
 class Payment < ActiveRecord::Base
   belongs_to :order
   attr_accessible :order_id

--- a/app/models/paypal_payment.rb
+++ b/app/models/paypal_payment.rb
@@ -1,4 +1,32 @@
 # encoding: UTF-8
+# == Schema Information
+#
+# Table name: payments
+#
+#  id                    :integer          not null, primary key
+#  price                 :integer
+#  paid_amount           :integer
+#  completed             :boolean
+#  completed_at          :datetime
+#  paypal_params         :text
+#  paypal_tx_id          :string(255)
+#  paypal_tx_type        :string(255)
+#  paypal_currency       :string(255)
+#  paypal_status         :string(255)
+#  paypal_payer_email    :string(255)
+#  manual_company_name   :string(255)
+#  manual_company_email  :string(255)
+#  manual_contact_person :string(255)
+#  manual_street_address :string(255)
+#  manual_post_code      :string(255)
+#  manual_invoice_sent   :boolean
+#  order_id              :integer
+#  type                  :string(255)
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  invoice_id            :string(255)
+#
+
 class PaypalPayment < Payment
   attr_accessible :completed, :completed_at, :paid_amount, :paypal_currency, :paypal_params, :paypal_payer_email, :paypal_status, :paypal_tx_id, :paypal_tx_type, :price
 

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: sponsors
+#
+#  id          :integer          not null, primary key
+#  name        :string(255)
+#  url         :string(255)
+#  imageUrl    :string(255)
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 class Sponsor < ActiveRecord::Base
   attr_accessible :description, :imageUrl, :name, :url
 

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: talks
+#
+#  id                        :integer          not null, primary key
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  title                     :string(255)
+#  description               :text
+#  talk_type_id              :integer
+#  talk_category_id          :integer
+#  presentation_file_name    :string(255)
+#  presentation_content_type :string(255)
+#  presentation_file_size    :integer
+#  presentation_updated_at   :datetime
+#
+
 class Talk < ActiveRecord::Base
   attr_accessible :title, :description, :talk_type, :talk_type_id, :talk_category, :talk_category_id, :presentation
 

--- a/app/models/talk_category.rb
+++ b/app/models/talk_category.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: talk_categories
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 class TalkCategory < ActiveRecord::Base
   attr_accessible :name
 

--- a/app/models/talk_type.rb
+++ b/app/models/talk_type.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: talk_types
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)
+#  duration   :integer
+#  visible    :boolean
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 class TalkType < ActiveRecord::Base
   attr_accessible :duration, :name, :visible
 

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: tickets
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)
+#  price      :integer
+#  active     :boolean
+#  visible    :boolean
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 class Ticket < ActiveRecord::Base
   attr_accessible :active, :name, :price, :visible
   validates_presence_of :name, :price

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                      :integer          not null, primary key
+#  email                   :string(255)      default(""), not null
+#  encrypted_password      :string(255)      default(""), not null
+#  reset_password_token    :string(255)
+#  reset_password_sent_at  :datetime
+#  remember_created_at     :datetime
+#  sign_in_count           :integer          default(0)
+#  current_sign_in_at      :datetime
+#  last_sign_in_at         :datetime
+#  current_sign_in_ip      :string(255)
+#  last_sign_in_ip         :string(255)
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  admin                   :boolean
+#  name                    :string(255)
+#  tlf                     :string(255)
+#  company                 :string(255)
+#  accepcted_privacy       :boolean
+#  accepted_optional_email :boolean
+#  twitter                 :string(255)
+#  allergies               :string(255)
+#  ticket_id               :integer
+#  order_id                :integer
+#  completed               :boolean
+#
+
 class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :token_authenticatable, :confirmable,

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: orders
+#
+#  id            :integer          not null, primary key
+#  comment       :string(255)
+#  completed     :boolean
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  owner_user_id :integer
+#
+
 require 'spec_helper'
 
 describe Order do

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -1,3 +1,31 @@
+# == Schema Information
+#
+# Table name: payments
+#
+#  id                    :integer          not null, primary key
+#  price                 :integer
+#  paid_amount           :integer
+#  completed             :boolean
+#  completed_at          :datetime
+#  paypal_params         :text
+#  paypal_tx_id          :string(255)
+#  paypal_tx_type        :string(255)
+#  paypal_currency       :string(255)
+#  paypal_status         :string(255)
+#  paypal_payer_email    :string(255)
+#  manual_company_name   :string(255)
+#  manual_company_email  :string(255)
+#  manual_contact_person :string(255)
+#  manual_street_address :string(255)
+#  manual_post_code      :string(255)
+#  manual_invoice_sent   :boolean
+#  order_id              :integer
+#  type                  :string(255)
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  invoice_id            :string(255)
+#
+
 require 'spec_helper'
 
 describe Payment do

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: sponsors
+#
+#  id          :integer          not null, primary key
+#  name        :string(255)
+#  url         :string(255)
+#  imageUrl    :string(255)
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 require 'spec_helper'
 
 describe Sponsor do

--- a/spec/models/talk_category_spec.rb
+++ b/spec/models/talk_category_spec.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: talk_categories
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 require 'spec_helper'
 
 describe TalkCategory do

--- a/spec/models/talk_spec.rb
+++ b/spec/models/talk_spec.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: talks
+#
+#  id                        :integer          not null, primary key
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  title                     :string(255)
+#  description               :text
+#  talk_type_id              :integer
+#  talk_category_id          :integer
+#  presentation_file_name    :string(255)
+#  presentation_content_type :string(255)
+#  presentation_file_size    :integer
+#  presentation_updated_at   :datetime
+#
+
 require 'spec_helper'
 
 describe Talk do

--- a/spec/models/talk_type_spec.rb
+++ b/spec/models/talk_type_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: talk_types
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)
+#  duration   :integer
+#  visible    :boolean
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 require 'spec_helper'
 
 describe TalkType do

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: tickets
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)
+#  price      :integer
+#  active     :boolean
+#  visible    :boolean
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 require 'spec_helper'
 
 describe Ticket do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                      :integer          not null, primary key
+#  email                   :string(255)      default(""), not null
+#  encrypted_password      :string(255)      default(""), not null
+#  reset_password_token    :string(255)
+#  reset_password_sent_at  :datetime
+#  remember_created_at     :datetime
+#  sign_in_count           :integer          default(0)
+#  current_sign_in_at      :datetime
+#  last_sign_in_at         :datetime
+#  current_sign_in_ip      :string(255)
+#  last_sign_in_ip         :string(255)
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  admin                   :boolean
+#  name                    :string(255)
+#  tlf                     :string(255)
+#  company                 :string(255)
+#  accepcted_privacy       :boolean
+#  accepted_optional_email :boolean
+#  twitter                 :string(255)
+#  allergies               :string(255)
+#  ticket_id               :integer
+#  order_id                :integer
+#  completed               :boolean
+#
+
 require 'spec_helper'
 describe User do
   describe ".new" do


### PR DESCRIPTION
Annotate is a gem which injects each model with a comment block
containing the actual columns representing the model in the database.
This sort of serves as an inline documentation and is somewhat useful.

The annotate gem will add an executable called 'annotate' in your path,
asumming you are using RVM or something equivalent, and running this
will update each model any changes made since last time.

**I know that some developers do not view model annotations as useful and thus deem it unnecessary. I therefore do not assume that this pull request will get accepted. It is merely a suggestion from my part.**
