### PR TITLE
Removing the accepcted_privacy column from User

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -32,7 +32,7 @@ class OrdersController < ApplicationController
       :ticket_id => params[:user][:ticket_id],
       :password => Devise.friendly_token.first(9),
       :company => @order.owner.company,
-      :accepcted_privacy => true
+      :accepted_privacy => "1"
     })
 
     @user.order_id = @order.id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,13 +5,15 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
+  attr_accessor :accepted_privacy
+
   # Setup accessible (or protected) attributes for your model
   attr_accessible :email, :password, :password_confirmation, :remember_me
-  attr_accessible :name, :tlf, :company, :accepcted_privacy, :twitter, :accepted_optional_email, :allergies, :ticket_id, :order
+  attr_accessible :name, :tlf, :company, :accepted_privacy, :twitter, :accepted_optional_email, :allergies, :ticket_id, :order
 
   # validations
   validates_presence_of :name, :tlf
-  validates_inclusion_of :accepcted_privacy, :in => [true]
+  validates_acceptance_of :accepted_privacy
 
   belongs_to :ticket
   belongs_to :order

--- a/app/views/devise/registrations/_form_common.html.haml
+++ b/app/views/devise/registrations/_form_common.html.haml
@@ -6,4 +6,4 @@
 = f.input :twitter, :placeholder => '@username'
 = f.input :allergies
 = f.input :accepted_optional_email, :label => 'Jeg ønsker epost om tilsvarende arrangementer'
-= f.input :accepcted_privacy, :label => 'Jeg aksepterer vilkårene'
+= f.input :accepted_privacy, :as => :boolean, :label => 'Jeg aksepterer vilkårene'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,10 +8,10 @@ en:
     attributes:
       user:
         email: "Email address"
-        accepcted_privacy: ""
+        accepted_privacy: ""
     errors:
       models:
         user:
           attributes:
-            accepcted_privacy:
-              inclusion: "You must accept."
+            accepted_privacy:
+              accepted: "You must accept."

--- a/db/migrate/20130406193005_remove_accept_privacy_column.rb
+++ b/db/migrate/20130406193005_remove_accept_privacy_column.rb
@@ -1,0 +1,5 @@
+class RemoveAcceptPrivacyColumn < ActiveRecord::Migration
+  def change
+    remove_column :users, :accepcted_privacy
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130325055758) do
+ActiveRecord::Schema.define(:version => 20130406193005) do
 
   create_table "orders", :force => true do |t|
     t.string   "comment"
@@ -107,7 +107,6 @@ ActiveRecord::Schema.define(:version => 20130325055758) do
     t.string   "name"
     t.string   "tlf"
     t.string   "company"
-    t.boolean  "accepcted_privacy"
     t.boolean  "accepted_optional_email"
     t.string   "twitter"
     t.string   "allergies"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     u.sequence(:email) { |n| "test#{n}@awesome.com"}
     u.password 'please123445'
     u.tlf '99900999'
-    u.accepcted_privacy true
+    u.accepted_privacy "1"
     u.ticket { FactoryGirl.create(:ticket) }
   end
 
@@ -13,7 +13,7 @@ FactoryGirl.define do
     u.sequence(:email) { |n| "test#{n}@awesome.com"}
     u.password 'please123445'
     u.tlf '99900999'
-    u.accepcted_privacy true
+    u.accepted_privacy "1"
     u.ticket { FactoryGirl.create(:ticket) }
     u.admin true
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,7 +19,7 @@ describe User do
         :email => "me@mail.com",
         :tlf => "92043382",
         :password => "lala12345",
-        :accepcted_privacy => true})
+        :accepted_privacy => "1"})
       user.valid?.should be_true
     end
   end


### PR DESCRIPTION
A model in Rails can have an attribute that does not exists in the
database by using #attr_accesssor, which will dynamically create
accessor methods for an instance variable with the given name.

Since a user must accept the privacy terms upon registrations, the only
value one is ever going to see in the database is 'true', making it
obviously not necessary to store. Everything behaves like it did before,
except that the true-value is not stored in the database.

See http://apidock.com/ruby/Module/attr_accessor for more information.
