### PR TITLE
Rewriting all actions of info to Markdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'paperclip'
 gem 'aws-sdk'
 gem 'jquery-rails'
 gem 'simple_form'
+gem 'rdiscount'
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,7 @@ GEM
     rb-fsevent (0.9.3)
     rb-inotify (0.8.8)
       ffi (>= 0.5.0)
+    rdiscount (2.0.7.1)
     rdoc (3.12)
       json (~> 1.4)
     rspec (2.12.0)
@@ -214,6 +215,7 @@ DEPENDENCIES
   rails (= 3.2.11)
   rb-fsevent
   rb-inotify (~> 0.8.8)
+  rdiscount
   rspec-rails
   sass-rails
   simple_form

--- a/app/views/info/about.html.haml
+++ b/app/views/info/about.html.haml
@@ -2,23 +2,18 @@
 
 .row
   .span4
-    %p
-      Vi tror at IT-prosjekter i Norge kan lære mye av prinsippene bak smidig
-      utvikling. Derfor arrangerer vi Smidigkonferansen for å dele erfaringer og bidra
-      til å øke kunnskapen om smidige metoder i Oslo og Norge.
+    :markdown
+      Vi tror at IT-prosjekter i Norge kan lære mye av prinsippene bak smidig utvikling. Derfor arrangerer vi
+      Smidigkonferansen for å dele erfaringer og bidra til å øke kunnskapen om smidige metoder i Oslo og Norge.
 
-    %p
-      Smidigkonferansen er en årlig konferanse for og av fagmiljøet selv.
-      Her får du høre hvordan andre prosjektdeltakere som deg takler hverdagen
-      i sine smidige og kanskje ikke så smidige prosjekter. Her får du stiftet
-      nye bekjentskaper som er i samme situasjon som deg selv. Du får forsterket
-      de bekjentskapene du har, og lært hvor mye både fagmiljøet og du selv har å
-      by på. I fjor var ca 20% av deltakerne også foredragsholdere, noe som
-      skaper en unik atmosfære. Ikke bare får du høre interessante foredrag, men
-      det er lett å snakke med foredragsholderne gjennom hele konferansen.
-
-    %p
+      Smidigkonferansen er en årlig konferanse for og av fagmiljøet selv. Her får du høre hvordan andre
+      prosjektdeltakere som deg takler hverdagen i sine smidige og kanskje ikke så smidige prosjekter. Her får du
+      stiftet nye bekjentskaper som er i samme situasjon som deg selv. Du får forsterket de bekjentskapene du har, og
+      lært hvor mye både fagmiljøet og du selv har å by på. I fjor var ca 20% av deltakerne også foredragsholdere, noe
+      som skaper en unik atmosfære. Ikke bare får du høre interessante foredrag, men det er lett å snakke med
+      foredragsholderne gjennom hele konferansen.
   .span8
-    =image_tag("os.jpg")
-  .span8.offset4
-    %em Årets konferanse er den syvende i rekken og finner sted i november 2013.
+    :markdown
+      ![Bilde fra tidligere Smidigkonferanse](#{image_path "os.jpg"})
+      *Årets konferanse er den syvende i rekken og finner sted i november 2013.*
+

--- a/app/views/info/index.html.haml
+++ b/app/views/info/index.html.haml
@@ -1,25 +1,30 @@
 .hero-unit
-  %h1 Smidig 2013
-  %p.main-meta
-    %em Arrangeres i Oslo, November 2013.
-    Mer info kommer.
+  :markdown
+    # Smidig 2013
+
+    *Arrangeres i Oslo, November 2013.* Mer info kommer.
 
 .row-fluid
   .span4
-    %h2 Om konferansen
-    %p
+    :markdown
+      ## Om konferansen
+
       Konferansen startet som...
-    %p
-      =link_to "Les mer om smidig", info_about_path
+
+      [Les mer om smidig](#{info_about_path})
   .span4
-    %h2 Sponse smidig?
-    %p
+    :markdown
+      ## Sponse smidig?
+
       Vi trenger din hjelp!
-    %p
-      =link_to "read more", info_sponsor_path
+
+      [read more](#{info_sponsor_path})
   .span4
-    %h2 Følg med
-    %p
-      Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui.
-    %p
-      =link_to "read more", info_about_path
+    :markdown
+      ## Følg med
+
+      Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris
+      condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod.
+      Donec sed odio dui.
+
+      [read more](#{info_about_path})

--- a/app/views/info/sponsor.html.haml
+++ b/app/views/info/sponsor.html.haml
@@ -1,23 +1,32 @@
 %h2 Vil din bedrift sponse smidig 2013?
 
-%p
-  Ta kontakt med <a href="mailto:kontakt@smidig.no">kontakt@smidig.no</a> dersom din bedrift er interessert i få vite mer om å sponse Smidig 2013.
-%p
-  Konferansen arrangeres av frivillige entusiaster og finansieres ved hjelp av deltakeravgift og sponsormidler. I dag er fokus på smidig prosjektgjennomføring enda viktigere enn tidligere, og stadig nye bedrifter og organisasjoner tar i bruk metodene og teknikkene. Som sponsor for Smidig 2013, viser dere at dere satser på metoder som gir kostnadseffektivitet og god kvalitet. Tidligere konferanser har hatt mange deltakere fra viktige IT-miljøer som f.eks. If, NRK, Statens Pensjonskasse, Skandiabanken, Finn.no, Skatteetaten og KLP.
-%p
-  Tidligere har vi sagt at det er viktig å understreke at smidige metoder ikke er én enkelt bedrifts kommersialiserte tanker og ideer, men derimot tankegodset til en hel bevegelse innenfor IT. Dette er også utgangspunktet for Smidig 2013. Vi ønsker at konferansen skal forbli et spleiselag, hvor alle sponsorer blir tilegnet like mye plass og oppmerksomhet. Å være sponsor for Smidig 2013 er et sterkt signal om at dere stiller seg bak bevegelsen for smidige metoder og støtter opp under det frivillige initiativet som er drivkraften bak arrangement. Alle sponsormidlene går direkte inn i konferansens drift.
-%p
-  Sponsorene går inn med kroner <strong>25 000,-</strong> hver og får for dette følgende:
-  %ul.sponsor-benefits
-    %li Bedriftens logo på konferansens hjemmeside
-    %li Bedriftens logo på alle trykksaker til konferansen (plakater, flyveblader, program)
-    %li Bedriftens logo på eventuell annonsering, for eksempel i Computerworld
-    %li Hederlig omtale i konferansens åpningstale
-    %li Rett til å benytte Smidig 2013 i bedriftens markedsføring
-    %li To deltakerbilletter til konferansen
-    %li Mulighet til å ha en pullup i fellesrom under konferanse
-    %li Mulighet til å gjøre ett A4-ark med informasjon om bedriften tilgjengelig for alle deltakerne under konferansen
+:markdown
+  Ta kontakt med [kontakt@smidig.no](mailto:kontakt@smidig.no) dersom din bedrift er interessert i få vite mer om å
+  sponse Smidig 2013.
 
-  %br
-  %strong
-    Ta kontakt med <a href="mailto:kontakt@smidig.no">kontakt@smidig.no</a> dersom din bedrift er interessert i få vite mer om å sponse Smidig 2013.
+  Konferansen arrangeres av frivillige entusiaster og finansieres ved hjelp av deltakeravgift og sponsormidler. I dag
+  er fokus på smidig prosjektgjennomføring enda viktigere enn tidligere, og stadig nye bedrifter og organisasjoner tar
+  i bruk metodene og teknikkene. Som sponsor for Smidig 2013, viser dere at dere satser på metoder som gir
+  kostnadseffektivitet og god kvalitet. Tidligere konferanser har hatt mange deltakere fra viktige IT-miljøer som
+  f.eks. If, NRK, Statens Pensjonskasse, Skandiabanken, Finn.no, Skatteetaten og KLP.
+
+  Tidligere har vi sagt at det er viktig å understreke at smidige metoder ikke er én enkelt bedrifts kommersialiserte
+  tanker og ideer, men derimot tankegodset til en hel bevegelse innenfor IT. Dette er også utgangspunktet for Smidig
+  2013. Vi ønsker at konferansen skal forbli et spleiselag, hvor alle sponsorer blir tilegnet like mye plass og
+  oppmerksomhet. Å være sponsor for Smidig 2013 er et sterkt signal om at dere stiller seg bak bevegelsen for smidige
+  metoder og støtter opp under det frivillige initiativet som er drivkraften bak arrangement. Alle sponsormidlene går
+  direkte inn i konferansens drift.
+
+  Sponsorene går inn med kroner <strong>25 000,-</strong> hver og får for dette følgende:
+
+  * Bedriftens logo på konferansens hjemmeside
+  * Bedriftens logo på alle trykksaker til konferansen (plakater, flyveblader, program)
+  * Bedriftens logo på eventuell annonsering, for eksempel i Computerworld
+  * Hederlig omtale i konferansens åpningstale
+  * Rett til å benytte Smidig 2013 i bedriftens markedsføring
+  * To deltakerbilletter til konferansen
+  * Mulighet til å ha en pullup i fellesrom under konferanse
+  * Mulighet til å gjøre ett A4-ark med informasjon om bedriften tilgjengelig for alle deltakerne under konferansen
+
+  **Ta kontakt med [kontakt@smidig.no](mailto:kontakt@smidig.no) dersom din bedrift er interessert i få vite mer om å
+  sponse Smidig 2013.**


### PR DESCRIPTION
Markdown parsing is currently done using the gem rdiscount.

Discount is an implementation of John Gruber's Markdown markup language
in C. It implements all of the language described in the markdown syntax
document and passes the Markdown 1.0 test suite.

The purpose of Markdown is to make ducuments easy-to-read and
easy-to-write. It is far better than Haml for inline content markup. See
http://goo.gl/kIh3Y for someone who shares my opinion.

I also took the liberty to introduce a 120 character line width
constraint on textual inline content such as what is seen in these
pages.
