### PR TITLE
Gemfile cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :tools do
   gem 'guard-test'
 end
 
-group :test, :development do
+group :development do
   gem 'sqlite3'
   gem 'guard'
   gem 'guard-rspec'
@@ -48,12 +48,13 @@ group :test, :development do
   gem 'guard-migrate'
   gem 'spork'
   gem 'spork-testunit'
-  gem 'rspec-rails'
-  gem 'factory_girl_rails', :require => false
 end
 
 group :test do
+  gem 'sqlite3'
   gem 'webmock'
+  gem 'rspec-rails'
+  gem 'factory_girl_rails', :require => false
 end
 
 # To use debugger


### PR DESCRIPTION
I have moved guard-test to its own gem-group called 'tools', which is recommended. I've also tried to dissolve the group containing gems for both the test environment and the development environment. These environments are **not** the same and does not contain the same gems by default.

However, since I do not use guard for anything, I cannot confirm that it is working. I suspect that I may have put them in wrong group or done something else wrong. Anyone who utilizes these tools should confirm the changes.
