### PR TITLE
Removing unnecessary markup

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -64,8 +64,7 @@
                   %a{:href => "http://www.facebook.com/smidig"} facebook.com
                 %li
                   %a{:href => "http://lanyrd.com/2013/smidig2013/"} lanyrd.com
-          .span12
-            %hr/
-            %p.copy
-              Copyright ©
-              %a{:href => "http://smidig2013.no"} Smidig 2013
+        %hr/
+        %p.copy
+          Copyright ©
+          %a{:href => "http://smidig2013.no"} Smidig 2013


### PR DESCRIPTION
Bootstrap demands rather heavy content markup, but some of it was not necessary.
