### PR TITLE
Reverting a mistake in a migration

### DIFF
--- a/db/migrate/20130221162143_add_belongs_to_order_on_user.rb
+++ b/db/migrate/20130221162143_add_belongs_to_order_on_user.rb
@@ -1,5 +1,5 @@
 class AddBelongsToOrderOnUser < ActiveRecord::Migration
   def change
-     add_column :user
+     add_column :users, :order_id, :integer
   end
 end


### PR DESCRIPTION
It seems that @k0piator mistakenly removed a part of an existing migration with @7189296. This reverts the change.
