### PR TITLE
Seeding a bogus company with administrators

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,6 +13,7 @@ administrators.each do |user_data|
       :password => 'password',
       :password_confirmation => 'password',
       :accepted_privacy => "1",
+      :company => 'Smidig 2013',
   })
 
   user = User.new user_data


### PR DESCRIPTION
`rake db:seed` broke with @6f68cdd, which added presence validation of company of users. This fixes it.
