### PR TITLE
Truncate database before seeding it with new data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development do
   gem 'guard-migrate'
   gem 'spork'
   gem 'spork-testunit'
+  gem 'database_cleaner'
 end
 
 group :test do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,8 @@
 # encoding: utf-8
 
+DatabaseCleaner.strategy = :truncation
+DatabaseCleaner.clean
+
 # This will seed administrators with their appropriate names and email addresses. Their password is 'password'.
 administrators = [
     {:name => "Jonas Amundsen",      :email => "jonasba@gmail.com"},


### PR DESCRIPTION
Reseeding without truncating the existing database violates a number of constraints, such as that only one user can be registered using one e-mail address. Thus, it makes sense to truncate it before seeding. This also allows one to better control the state of the database during development.

Simply using DatabaseCleaner, which is already installed and used in the test environment.

``` ruby
DatabaseCleaner.strategy = :truncation
DatabaseCleaner.clean
```

I am actually surprised that no one has encountered errors regarding this before. I tried looking at the logs, but I couldn't find any related changes. Why this might have worked before is beyond me right now...
