### PR TITLE
Prefixing sponsor URL with default scheme

### DIFF
--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -4,5 +4,13 @@ class Sponsor < ActiveRecord::Base
 
   # validations
   validates_presence_of :name
-  # Legg på http hvis det mangler på url
+
+  before_save :prefix_url_with_default_scheme, :if => :url_changed?
+
+  private
+
+  def prefix_url_with_default_scheme
+    uri = URI.parse(self.url)
+    self.url = "http://#{url}" if uri.scheme.nil?
+  end
 end


### PR DESCRIPTION
In case a scheme is missing in the sponsor URL, it will now automatically prepend 'http://' to the string. Parsing is done using Ruby's own [URI](http://www.ruby-doc.org/stdlib-2.0/libdoc/uri/rdoc/URI.html), which is RFC compliant.
