### PR TITLE
DRYing up method for prefixing URIs with schema.

### DIFF
--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -7,10 +7,5 @@ class Sponsor < ActiveRecord::Base
 
   before_save :prefix_url_with_default_scheme, :if => :url_changed?
 
-  private
-
-  def prefix_url_with_default_scheme
-    uri = URI.parse(self.url)
-    self.url = "http://#{url}" if uri.scheme.nil?
-  end
+  add_default_scheme :url, :imageUrl
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,8 @@ require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
 
+require 'add_default_scheme'
+
 if defined?(Bundler)
   # If you precompile assets before deploying to production, use this line
   Bundler.require(*Rails.groups(:assets => %w(development test)))
@@ -16,7 +18,7 @@ module ConferenceApp
     # -- all .rb files in that directory are automatically loaded.
 
     # Custom directories with classes and modules you want to be autoloadable.
-    # config.autoload_paths += %W(#{config.root}/extras)
+    config.autoload_paths += %W(#{config.root}/lib)
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/lib/add_default_scheme.rb
+++ b/lib/add_default_scheme.rb
@@ -1,0 +1,32 @@
+module AddDefaultScheme
+  class ActiveRecord::Base
+    private
+
+    def self.add_default_scheme(*args)
+      fields = args.select do |arg|
+        !arg.is_a?(Hash)
+      end
+
+      options = { :default_scheme => 'http' }
+
+      args.each do |arg|
+        options.merge!(arg) if arg.is_a?(Hash)
+      end
+
+      fields.each do |field|
+        define_method "#{field}=" do |value|
+          begin
+            if URI.parse(value).scheme.nil?
+              super("#{options[:default_scheme]}://#{value}")
+            else
+              super(value)
+            end
+          rescue
+            super(value)
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/spec/factories/sponsor.rb
+++ b/spec/factories/sponsor.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :sponsor do |o|
+    o.name 'Smidig 2013 Sponsor'
+  end
+end

--- a/spec/lib/add_default_scheme_spec.rb
+++ b/spec/lib/add_default_scheme_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe AddDefaultScheme do
+  describe "add_default_scheme" do
+    it "should create setters setting a default scheme when none is present" do
+      Sponsor.send(:add_default_scheme, :url)
+
+      sponsor = FactoryGirl.build(:sponsor)
+      sponsor.url = "url-without-a-scheme.com"
+      sponsor.url.should eq("http://url-without-a-scheme.com")
+    end
+
+    it "should set a specific scheme if specified" do
+      Sponsor.send(:add_default_scheme, :url, :default_scheme => "https")
+
+      sponsor = FactoryGirl.build(:sponsor)
+      sponsor.url = "url-without-a-scheme.com"
+      sponsor.url.should eq("https://url-without-a-scheme.com")
+    end
+
+    it "should allow for multiple uri fields being specified at once" do
+      Sponsor.send(:add_default_scheme, :url, :imageUrl)
+
+      sponsor = FactoryGirl.build(:sponsor)
+      sponsor.imageUrl = "url-without-a-scheme.com"
+      sponsor.imageUrl.should eq("http://url-without-a-scheme.com")
+    end
+
+    it "should not do anything when provided with a specified scheme" do
+      Sponsor.send(:add_default_scheme, :url)
+
+      sponsor = FactoryGirl.build(:sponsor)
+      sponsor.url = "ftp://url-with-a-scheme.com"
+      sponsor.url.should eq("ftp://url-with-a-scheme.com")
+    end
+
+    it "should not do anything when provided an invalid URI" do
+      Sponsor.send(:add_default_scheme, :url)
+
+      sponsor = FactoryGirl.build(:sponsor)
+      sponsor.url = "invalid uri"
+      sponsor.url.should eq("invalid uri")
+    end
+  end
+end

--- a/spec/views/sponsors/index.html.haml_spec.rb
+++ b/spec/views/sponsors/index.html.haml_spec.rb
@@ -6,13 +6,13 @@ describe "sponsors/index" do
       stub_model(Sponsor,
         :name => "Name",
         :url => "Url",
-        :imageUrl => "Image Url",
+        :imageUrl => "ImageUrl",
         :description => "MyText"
       ),
       stub_model(Sponsor,
         :name => "Name",
         :url => "Url",
-        :imageUrl => "Image Url",
+        :imageUrl => "ImageUrl",
         :description => "MyText"
       )
     ])
@@ -22,8 +22,8 @@ describe "sponsors/index" do
     render
     # Run the generator again with the --webrat flag if you want to use webrat matchers
     assert_select "tr>td", :text => "Name".to_s, :count => 2
-    assert_select "tr>td", :text => "Url".to_s, :count => 2
-    assert_select "tr>td", :text => "Image Url".to_s, :count => 2
+    assert_select "tr>td", :text => "http://Url".to_s, :count => 2
+    assert_select "tr>td", :text => "http://ImageUrl".to_s, :count => 2
     assert_select "tr>td", :text => "MyText".to_s, :count => 2
   end
 end


### PR DESCRIPTION
As I noticed that there were more fields containing URIs, I realized that there were need for a more DRY method of assigning a 'prefix-with-default-scheme' property to fields. A module contained in ./lib now does this. It is automatically required in the application and used the following way.

``` ruby
class Sponsor < ActiveRecord::Base
  add_default_scheme :url, :imageUrl, :default_scheme => 'https'
end
```

This will dynamically generate wrapper methods around the setters for the fields specified and prepend a scheme to the value.

``` ruby
sponsor = Sponsor.new
sponsor.url = 'url-without-scheme'
puts sponsor.url # => 'https://url-without-scheme'
```
