### PR TITLE
Moving lib inclusion into an configuration block

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -2,8 +2,6 @@ require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
 
-require 'add_default_scheme'
-
 if defined?(Bundler)
   # If you precompile assets before deploying to production, use this line
   Bundler.require(*Rails.groups(:assets => %w(development test)))
@@ -74,5 +72,9 @@ module ConferenceApp
     # Prevent app to connecto to database during initialization.
     # https://devcenter.heroku.com/articles/rails-asset-pipeline#troubleshooting
     config.assets.initialize_on_precompile = false
+
+    config.before_initialize do
+      require 'add_default_scheme'
+    end
   end
 end


### PR DESCRIPTION
This resolves the problem with load path not being set before requiring the library, which ensured that 'rails server' failed hard. See discussion in #45.
